### PR TITLE
Feature/handle view args

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - development
 
   pull_request: {}
   workflow_dispatch: {}

--- a/.github/workflows/release_package_development.yml
+++ b/.github/workflows/release_package_development.yml
@@ -1,4 +1,4 @@
-name: Release pypi package
+name: Release pypi dev-package
 
 env:
   python-version: 3.8
@@ -7,7 +7,7 @@ on:
   workflow_run:
     workflows: ["Lint and test"]
     types: [completed]
-    branches: [main]
+    branches: [development]
 
 jobs:
   publish:
@@ -37,7 +37,7 @@ jobs:
           pipenv install --deploy --dev
 
       - name: Build tarball
-        run: python setup.py sdist
+        run: python setup.py sdist --build=dev${{ github.run_number }}
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2

--- a/src/origin/api/endpoint.py
+++ b/src/origin/api/endpoint.py
@@ -13,7 +13,8 @@ class Endpoint(object):
     Request = None
     Response = None
 
-    # view arguments retrieved from the request url path eg. /api/v1/users/<user_id>
+    # view arguments retrieved from the request url path
+    # eg. /api/v1/users/<user_id>
     View_args = None
 
     @abstractmethod
@@ -59,7 +60,7 @@ class Endpoint(object):
         """
         return (self.request_schema is not None
                 and 'request' in getfullargspec(self.handle_request)[0])
-    
+
     @cached_property
     def should_parse_view_args(self) -> bool:
         """

--- a/src/origin/api/endpoint.py
+++ b/src/origin/api/endpoint.py
@@ -13,6 +13,9 @@ class Endpoint(object):
     Request = None
     Response = None
 
+    # view arguments retrieved from the request url path eg. /api/v1/users/<user_id>
+    View_args = None
+
     @abstractmethod
     def handle_request(self, **kwargs) -> Optional[Any]:
         """
@@ -34,6 +37,13 @@ class Endpoint(object):
         """
         return self.Response
 
+    @property
+    def view_args_schema(self) -> Optional[Type[Any]]:
+        """
+        Variables passed in the URL path. eg. /api/v1/users/<user_id>
+        """
+        return self.View_args
+
     @cached_property
     def requires_context(self) -> bool:
         """
@@ -49,3 +59,12 @@ class Endpoint(object):
         """
         return (self.request_schema is not None
                 and 'request' in getfullargspec(self.handle_request)[0])
+    
+    @cached_property
+    def should_parse_view_args(self) -> bool:
+        """
+        Returns True if handle_request() requires an instance of self.View_args
+        passed as argument.
+        """
+        return (self.view_args_schema is not None
+                and 'view_args' in getfullargspec(self.handle_request)[0])

--- a/src/origin/api/orchestration.py
+++ b/src/origin/api/orchestration.py
@@ -82,11 +82,15 @@ class RequestOrchestrator(object):
         self.data = data
         self.secret = secret
         self.guards = guards
+        self.view_args = {}
 
-    def __call__(self) -> flask.Response:
+    def __call__(self, **view_args) -> flask.Response:
         """
         Invoked by Flask to handle a HTTP request.
         """
+        
+        self.view_args = view_args
+
         try:
             return self._invoke_endpoint()
         except HttpResponse as e:
@@ -136,6 +140,12 @@ class RequestOrchestrator(object):
             handler_kwargs['request'] = self._parse_request_data(
                 data=self.data.get() or {},
                 schema=self.endpoint.request_schema,
+            )
+        
+        if self.endpoint.should_parse_view_args:
+            handler_kwargs['view_args'] = self._parse_request_data(
+                data=self.view_args or {},
+                schema=self.endpoint.view_args_schema,
             )
 
         # -- Invoke endpoint -------------------------------------------------

--- a/src/origin/api/orchestration.py
+++ b/src/origin/api/orchestration.py
@@ -88,7 +88,7 @@ class RequestOrchestrator(object):
         """
         Invoked by Flask to handle a HTTP request.
         """
-        
+
         self.view_args = view_args
 
         try:
@@ -141,7 +141,7 @@ class RequestOrchestrator(object):
                 data=self.data.get() or {},
                 schema=self.endpoint.request_schema,
             )
-        
+
         if self.endpoint.should_parse_view_args:
             handler_kwargs['view_args'] = self._parse_request_data(
                 data=self.view_args or {},


### PR DESCRIPTION
Previously using variable rules weren't an option as they weren't accepted by the RequestOrchestrator in the __call__() function.

paths using variable rules like: 
`/people/<person_id>/name`
would result in an error saying:
`TypeError: __call__() got an unexpected keyword argument 'person_id'`